### PR TITLE
Update webpack dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "style-loader": "^1.2.1",
     "ts-loader": "^8.0.11",
     "typescript": "3.8.3",
-    "webpack": "^4.43.0",
+    "webpack": "^5.12.3",
     "webpack-cli": "^3.3.11",
     "webpack-merge": "^5.4.0"
   }


### PR DESCRIPTION
Due to centreon/frontend-core migration to webpack 5, the build process will fail