### PR TITLE
chore(ci): harden pnpm install with supply chain security flags

### DIFF
--- a/scripts/create-archive.sh
+++ b/scripts/create-archive.sh
@@ -25,7 +25,11 @@ if ! cd "$ROOT_DIR"/src/react; then
 fi
 
 echo install dependencies
-if ! pnpm install; then
+if ! pnpm install \
+    --frozen-lockfile \
+    --config.trustPolicy=no-downgrade \
+    --config.minimumReleaseAge=2880 \
+    --config.blockExoticSubdeps=true; then
     fatal_error "Installing dependencies failed"
 fi
 


### PR DESCRIPTION
## Description

Add supply chain security flags to all `pnpm install` commands:
- `--config.trustPolicy=no-downgrade`
- `--config.minimumReleaseAge=2880`
- `--config.blockExoticSubdeps=true`

**Fixes** MON-197308

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Hardened pnpm install by adding supply chain security flags


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99871439?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->